### PR TITLE
Ensure a connection is initialized when sharing connections between Dbs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
   - "6"
-postgresql: "9.4"
+
+addons:
+  postgresql: "9.4"
 
 before_script:
   - "psql -c 'create database myapp_test;' -U postgres"

--- a/test/06_connection_options.coffee
+++ b/test/06_connection_options.coffee
@@ -1,0 +1,26 @@
+{exec} = require "child_process"
+pg = require "../"
+
+connectionStr = "pg://postgres@localhost/myapp_test?poolSize=5"
+
+describe "Connection options with pooling", ->
+	@timeout 10000 # ms
+
+	schemaName = "pool_test_schema"
+
+	db = pg connectionStr
+
+	before (done) ->
+		db.query "CREATE SCHEMA IF NOT EXISTS #{schemaName}", done
+
+	after (done) ->
+		db.query "DROP SCHEMA IF EXISTS #{schemaName}", done
+
+	it "initializes every connection using same options", (done) ->
+
+		# due to complex initialization, this test must be run without any previous pg usage
+
+		cmd = "coffee #{__dirname}/06_connection_options/test.coffee \"#{connectionStr}&searchPath=#{schemaName}\" #{schemaName}"
+		exec cmd, (err, stdout, stderr) ->
+			return done(stderr or err) if err
+			done()

--- a/test/06_connection_options/test.coffee
+++ b/test/06_connection_options/test.coffee
@@ -1,0 +1,32 @@
+async = require "async"
+pg = require "../../"
+
+unless connectionStr = process.argv[2]
+	console.error 'Missing connection string'
+	process.exit 1
+
+unless schemaName = process.argv[3]
+	console.error 'Missing schema name'
+	process.exit 1
+
+async.series [
+	(next) ->
+		pg(connectionStr).query "SELECT 1", next
+
+	(next) ->
+		async.times 3, (i, next) ->
+			pg(connectionStr).queryAll "SELECT 1", next
+		, next
+
+	(next) ->
+		db = pg(connectionStr)
+		async.timesSeries 3, (i, next) ->
+			db.queryOne 'SHOW search_path', (e, r) ->
+				return next e if e
+				searchPath = r.search_path
+				return next "Expected search_path '#{searchPath}' to be '#{schemaName}' (query ##{i+1})" if searchPath isnt schemaName
+				next()
+		, next
+], (e) ->
+	console.error e if e
+	process.exit Number(e?)


### PR DESCRIPTION
Example log of Db instance and two pg connections (A and B):
  - obtained A
  - A's options are optsInQueue: false, optsSet: false
  - setting A options and optsInQueue: true
  - A: calling "BEGIN"
  - A: calling "SET SEARCH_PATH = my_schema"
  - A: calling "SELECT VERSION()"
  - A: calling "COMMIT"
  - returned A
  - connection requested
  - obtained B
  - B's options are optsInQueue: true, optsSet: false // options are not really in the B's queue
  - A's options are now set
  - B: calling "SHOW search_path" // returns "public" instead of "my_schema"
  - returned B